### PR TITLE
Dev

### DIFF
--- a/odm_templates.py
+++ b/odm_templates.py
@@ -22,9 +22,9 @@ class Field(DynamicDocument):
 
 
 class Types(DynamicDocument):
-    name = StringField(required=True, unique=True)  # unique_with='owner'?  or base_type?
-    description = StringField(required=True)
     parent_type = StringField(required=True)
+    name = StringField(required=True, unique_with=parent_type)  # unique_with='owner'?  or base_type?
+    description = StringField(required=True)
     field_list = ListField(ReferenceField(Field, dbref=True, reverse_delete_rule=mongoengine.DENY))
     version = StringField()
 


### PR DESCRIPTION
fix to enable the same type name when the parent types are different.  eg. 'snapshot' request and 'snapshot' result
